### PR TITLE
Fix isort lines after import conflict with black & flake8 rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,17 +19,17 @@ repos:
     hooks:
       - id: python-check-blanket-noqa
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
-
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
       - id: black
         args: ["-l", "119"]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ line-length = 119
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-lines_after_imports = 1
+lines_after_imports = 2
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 
 [build-system]


### PR DESCRIPTION
While attempting to commit some code, pre-commit kept throwing issues about isort modifying files, and THEN black modifying them back again, and then flake8 going mad. Turns out the lines-after-import rules were out of sync. 

This PR should solve these issues.